### PR TITLE
[main] pdx206: Override fstab suffix

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -19,7 +19,9 @@ TARGET_BOOTLOADER_BOARD_NAME := XQ-AS52
 # Platform
 PRODUCT_PLATFORM := edo
 
+# Kernel cmdline
 BOARD_KERNEL_CMDLINE += androidboot.hardware=pdx206
+BOARD_KERNEL_CMDLINE += androidboot.fstab_suffix=pdx206
 
 # Partition information
 BOARD_FLASH_BLOCK_SIZE := 131072 # (BOARD_KERNEL_PAGESIZE * 64)


### PR DESCRIPTION
The default suffix of stock 11 bootloader is androidboot.fstab_suffix=default, so fix it

Detail: https://github.com/sonyxperiadev/device-sony-pdx201/pull/24