### PR TITLE
[4/4] [R] sensors: Configure device-specific orientation of LSM6DSM/AK0991

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -61,6 +61,11 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/firmware/R-cs35l41-dsp1-spk-cali.bin:$(TARGET_COPY_OUT_VENDOR)/firmware/R-cs35l41-dsp1-spk-cali.bin \
     $(DEVICE_PATH)/vendor/firmware/R-cs35l41-dsp1-spk-prot.bin:$(TARGET_COPY_OUT_VENDOR)/firmware/R-cs35l41-dsp1-spk-prot.bin
 
+# Device-specific magnetometer and IMU orientation
+PRODUCT_COPY_FILES += \
+    $(DEVICE_PATH)/vendor/etc/sensors/config/kona_ak991x_0_somc_product.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/kona_ak991x_0_somc_product.json \
+    $(DEVICE_PATH)/vendor/etc/sensors/config/kona_lsm6dsm_0_somc_product.json:$(TARGET_COPY_OUT_VENDOR)/etc/sensors/config/kona_lsm6dsm_0_somc_product.json
+
 # Device Init
 PRODUCT_PACKAGES += \
     fstab.pdx206 \

--- a/rootdir/vendor/etc/sensors/config/kona_ak991x_0_somc_product.json
+++ b/rootdir/vendor/etc/sensors/config/kona_ak991x_0_somc_product.json
@@ -1,0 +1,58 @@
+{
+  "config":
+  {
+    "hw_platform": ["MTP", "Surf", "QRD"],
+    "soc_id": ["356"]
+  },
+  "ak0991x_0_platform":{
+    "owner": "sns_ak0991x",
+    ".orient":{
+      "owner": "sns_ak0991x",
+      "x":{ "type": "str", "ver": "1",
+        "data": "+x"
+      },
+      "y":{ "type": "str", "ver": "1",
+        "data": "-y"
+      },
+      "z":{ "type": "str", "ver": "1",
+        "data": "-z"
+      }
+    },
+    ".mag":{
+      "owner": "sns_ak0991x",
+      ".fac_cal":{
+        "owner": "sns_ak0991x",
+        ".corr_mat":{
+          "owner": "sns_ak0991x",
+          "0_0":{ "type": "flt", "ver": "2",
+            "data": "1.101699"
+          },
+          "0_1":{ "type": "flt", "ver": "2",
+            "data": "0.069398"
+          },
+          "0_2":{ "type": "flt", "ver": "2",
+            "data": "-0.00348"
+          },
+          "1_0":{ "type": "flt", "ver": "2",
+            "data": "0.069398"
+          },
+          "1_1":{ "type": "flt", "ver": "2",
+            "data": "1.050891"
+          },
+          "1_2":{ "type": "flt", "ver": "2",
+            "data": "0.006959"
+          },
+          "2_0":{ "type": "flt", "ver": "2",
+            "data": "-0.00348"
+          },
+          "2_1":{ "type": "flt", "ver": "2",
+            "data": "0.006959"
+          },
+          "2_2":{ "type": "flt", "ver": "2",
+            "data": "1.074694"
+          }
+        }
+      }
+    }
+  }
+}

--- a/rootdir/vendor/etc/sensors/config/kona_lsm6dsm_0_somc_product.json
+++ b/rootdir/vendor/etc/sensors/config/kona_lsm6dsm_0_somc_product.json
@@ -1,0 +1,21 @@
+{
+  "config":{
+    "hw_platform": ["MTP", "Surf", "QRD"],
+    "soc_id": ["356"]
+  },
+  "lsm6dsm_0_platform":{
+    "owner": "lsm6dsm",
+    ".orient":{
+      "owner": "lsm6dsm",
+      "x":{ "type": "str", "ver": "1",
+        "data": "-x"
+      },
+      "y":{ "type": "str", "ver": "1",
+        "data": "+y"
+      },
+      "z":{ "type": "str", "ver": "1",
+        "data": "-z"
+      }
+    }
+  }
+}


### PR DESCRIPTION
PDX203 and PDX206 have the LSM6DSM 6DoF IMU (Inertial Measurement Unit) and AK0991 magnetometer mounted at a different orientation, resulting in one of the two devices orienting itself wrongly.  That difference is compensated for in aptly-named `_somc_product` overlay files, which are moved into its corresponding device repo here to account for the difference in the `".orient"` section.