### PR TITLE
Enable high refresh rate & dynamic refresh rate

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -93,6 +93,10 @@ PRODUCT_PROPERTY_OVERRIDES := \
 # Dynamic Refresh Rate
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.surface_flinger.use_content_detection_for_refresh_rate=true
 
+# Refresh Rate timers
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.surface_flinger.set_display_power_timer_ms=1000
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.surface_flinger.set_idle_timer_ms=80
+
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/edo/platform.mk)
 

--- a/device.mk
+++ b/device.mk
@@ -90,6 +90,9 @@ PRODUCT_PROPERTY_OVERRIDES := \
     ro.sf.lcd_density=420 \
     ro.usb.pid_suffix=20d
 
+# Dynamic Refresh Rate
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += ro.surface_flinger.use_content_detection_for_refresh_rate=true
+
 # Inherit from those products. Most specific first.
 $(call inherit-product, device/sony/edo/platform.mk)
 

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -34,6 +34,22 @@
     <!-- If true, the doze component is not started until after the screen has been turned off
          and the screen off animation has been performed. -->
     <bool name="config_dozeAfterScreenOffByDefault">true</bool>
+     
+     <!-- The default peak refresh rate for a given device. Change this value if you want to prevent
+         the framework from using higher refresh rates, even if display modes with higher refresh
+         rates are available from hardware composer. Only has an effect if the value is
+         non-zero. -->
+    <integer name="config_defaultPeakRefreshRate">120</integer>
+     
+         <!-- The default refresh rate for a given device. Change this value to set a higher default
+         refresh rate. If the hardware composer on the device supports display modes with a higher
+         refresh rate than the default value specified here, the framework may use those higher
+         refresh rate modes if an app chooses one by setting preferredDisplayModeId or calling
+         setFrameRate().
+         If a non-zero value is set for config_defaultPeakRefreshRate, then
+         config_defaultRefreshRate may be set to 0, in which case the value set for
+         config_defaultPeakRefreshRate will act as the default frame rate. -->
+    <integer name="config_defaultRefreshRate">60</integer>
 
     <!-- If true, the display will be shifted around in ambient mode. -->
     <bool name="config_enableBurnInProtection">true</bool>

--- a/overlay/packages/apps/Settings/res/values/config.xml
+++ b/overlay/packages/apps/Settings/res/values/config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+          http://www.apache.org/licenses/LICENSE-2.0
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and 
+     limitations under the License.
+-->
+<resources>
+
+    <!-- Whether to show Smooth Display feature in Settings Options -->
+    <bool name="config_show_smooth_display">true</bool>
+
+</resources>


### PR DESCRIPTION
This pull request enables:

1. HRR (High Refresh Rate)
2. Dynamic HRR based on content detection
3. HRR toggle in settings

And configures refresh rate timers to:

1. Switch to default refresh rate after 80ms of no surface updates
2. Use default refresh rate for 1 second during the wakeup of display (Including AOD)

This PR has to be tested. I do not have HRR device but it should work just fine.